### PR TITLE
Make RoomDB emit events when facts are asserted and retracted.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@living-room/database-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -221,9 +221,9 @@
       }
     },
     "@living-room/parser-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@living-room/parser-js/-/parser-js-0.1.0.tgz",
-      "integrity": "sha512-Sy+Q4PI4/tex3Y6cHJpscB8uKoVfpCx3rOMedz/nGSKEHBpKlAlPXwtaz2dqdt1jrl7lpjEqaPP01QL01nhXKQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@living-room/parser-js/-/parser-js-0.4.0.tgz",
+      "integrity": "sha512-YQFMf9ZNJ+5jEfmqCHJJv9eYudUkoj7vazVmXoVZYz6tYllWfL5hNCWATbPVSHFI3zUTfL02Tkf/4R4SBGfmZw==",
       "requires": {
         "ohm-js": "0.14.0"
       }

--- a/src/AbstractClient.js
+++ b/src/AbstractClient.js
@@ -1,9 +1,11 @@
 const parse = require('@living-room/parser-js')
+const EventEmitter = require('events')
 
 const MAX_PARSE_CACHE_SIZE = 1000
 
-module.exports = class AbstractClient {
+module.exports = class AbstractClient extends EventEmitter {
   constructor (id) {
+    super()
     this._id = id
     this._parseCache = new Map()
     this._asserts = []

--- a/src/LocalClient.js
+++ b/src/LocalClient.js
@@ -5,6 +5,10 @@ module.exports = class LocalClient extends AbstractClient {
   constructor (db, id) {
     super(id)
     this._db = db
+
+    // TODO: If there's a way for clients to be destroyed, they need to .off() these listeners.
+    db.on('assert', changes => this.emit('assert', changes))
+    db.on('retract', changes => this.emit('retract', changes))
   }
 
   /**
@@ -17,7 +21,7 @@ module.exports = class LocalClient extends AbstractClient {
     const jsonPatterns = patterns.map(patternString =>
       this._toJSONFactOrPattern(patternString)
     )
-    return this._db.on(JSON.stringify(jsonPatterns), callback)
+    return this._db.on(`pattern:${JSON.stringify(jsonPatterns)}`, callback)
   }
 
   select (...patternStrings) {


### PR DESCRIPTION
This also changes how clients subscribe to patterns slightly: they need to use `.on("pattern:{…}")` to allow for bare event names, too.